### PR TITLE
add load conn info from config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
 obs-cli
 dist/

--- a/README.md
+++ b/README.md
@@ -33,11 +33,22 @@ To install obs-cli, simply run:
 
 ## Usage
 
+Load connection info from toml config. A valid `config.toml` might look like this:
+
+```toml
+[connection]
+Host="localhost"
+Port=4455
+Password="mystrongpass"
+```
+
+It should be placed in `home directory / .obs_cli /`
+
 All commands support the following flags:
 
-- `--host`: which OBS instance to connect to
-- `--port`: port to connect to
-- `--password`: password used for authentication
+-   `--host`: which OBS instance to connect to
+-   `--port`: port to connect to
+-   `--password`: password used for authentication
 
 ### Streams
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/muesli/obs-cli
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v1.2.0
 	github.com/andreykaipov/goobs v0.10.0
-	github.com/dustin/go-humanize v1.0.0
 	github.com/muesli/coral v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
+github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/andreykaipov/goobs v0.10.0 h1:wa4CxbYu/NqwUmx5E4/baDqYRYEmfHwg2T23RAg3jlU=
 github.com/andreykaipov/goobs v0.10.0/go.mod h1:EqG73Uu/4npyhXIWWszgRelNkEeIz+d0slUT6NKWYs4=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -5,8 +7,6 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
-github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=


### PR DESCRIPTION
Hi, thanks for your efforts in adding support for websocket v5!

I've added the ability to read connection info from a config.toml placed in home user directory / .obs_cli /

It only reads from file if flags values are default, so setting conn info with flags should override it.

I noticed also that one of the todos is to get the recording file name. StopRecord should return the reponse field outputPath as listed [here](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#stoprecord) but I don't think the response field is added to [xx_generated.stoprecord.go](https://github.com/andreykaipov/goobs/blob/master/api/requests/record/xx_generated.stoprecord.go) unless I'm missing something.

Thank you for your time.